### PR TITLE
testing router.refresh() for dynamic page imitation

### DIFF
--- a/components/createLog.js
+++ b/components/createLog.js
@@ -5,6 +5,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { Modal, Button, Menu } from '@mantine/core';
 import classes from '@styles/createLog.module.css';
 import apiUrl from '../lib/apiUrl';
+import { useRouter } from 'next/router'
 
 export const dynamic = 'force-dynamic';
 // sets this to be a dynamic route (vs static) in netlify build. Needs to be dynamic 
@@ -18,6 +19,7 @@ export default function Page({ onSignal }) {
     const spanRef = useRef(null); // needed to attach span text to formdata (formdata won't pick it up on its own)
     // used a span here for styling purposes (make the text input look like twitter's tweet drafting; a regular input can't look like it)
     const [opened, { open, close }] = useDisclosure(false); // modal open/close
+    const router = useRouter();
 
     // creates options for multiselect dropdown component
     const createOption = (label) => ({
@@ -101,6 +103,7 @@ export default function Page({ onSignal }) {
             console.log(data)
             sendSignal();
             close();
+            router.refresh();
 
             // ...
         } catch (error) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,12 @@
 import Head from 'next/head'
-import Header from '@components/Header'
-import Footer from '@components/Footer'
+// import Header from '@components/Header'
+// import Footer from '@components/Footer'
 import Link from 'next/link'
 
 export default function Home() {
     return (
         <div className="container">
-        <Head>
+        {/* <Head>
             <title>Next.js Starter!</title>
             <link rel="icon" href="/favicon.ico" />
         </Head>
@@ -17,10 +17,9 @@ export default function Home() {
             Get started by editing <code>pages/index.js</code>
             </p>
         </main>
-        {/* <Prisma_test/> */}
         <Link href="/page">Test page</Link>
         <Link href="/logs">Logs Page</Link>
-        <Footer />
+        <Footer /> */}
         </div>
     )
 }

--- a/pages/logs.js
+++ b/pages/logs.js
@@ -4,6 +4,7 @@ import { Avatar, Group, Paper, Text, Button, Badge, Loader, Menu, Switch} from '
 //import classes from '@styles/CommentHtml.module.css';
 import CreateLog from '../components/createLog';
 import apiUrl from '../lib/apiUrl';
+import { useRouter } from 'next/router';
 
 import {
     IconSettings,
@@ -22,10 +23,10 @@ import {
 
 import classes from '../styles/logs.module.css'
 
-export const dynamic = 'force-dynamic'; // sets this to be a dynamic route (vs static) in netlify build. Needs to be dynamic 
+// export const dynamic = 'force-dynamic'; // sets this to be a dynamic route (vs static) in netlify build. Needs to be dynamic 
 // in order to properly avoid problems when one page is doing all fetching during the build time and showing same static page
-// even after data updates
-export const revalidate = 0;
+// even after data updates NOTE: Doesn't work in pages router
+// export const revalidate = 0; // NOTE: Doesn't work in pages router
 
 // this technically works, but ... this data probably shouldn't be publicky cached??
 // export async function getStaticProps(){
@@ -52,6 +53,7 @@ export default function Page() {
     const [isLoading, setIsLoading] = useState(false)
     const [opened, setOpened] = useState(false); // menu items
     const [checked, setChecked] = useState(false); // lightmode/darkmode
+    const router = useRouter();
 
     async function fetchData() {
         try{
@@ -81,6 +83,7 @@ export default function Page() {
             }
             // const data = await response.json()
             // console.log(data)
+            router.refresh();
         } catch (e){
             console.error(e)
         }

--- a/pages/logs.js
+++ b/pages/logs.js
@@ -22,7 +22,7 @@ import {
 
 import classes from '../styles/logs.module.css'
 
-//export const dynamic = 'force-dynamic'; // sets this to be a dynamic route (vs static) in netlify build. Needs to be dynamic 
+export const dynamic = 'force-dynamic'; // sets this to be a dynamic route (vs static) in netlify build. Needs to be dynamic 
 // in order to properly avoid problems when one page is doing all fetching during the build time and showing same static page
 // even after data updates
 export const revalidate = 0;


### PR DESCRIPTION
From stackoverflow: When it comes to the Router Cache, you cannot configure a Page to be dynamic or not. Declarations like export const dynamic = 'force-dynamic' or export const dynamic = 'auto' are not respected for Pages. Likewise, the cache options for your fetch requests do not matter.

The only ways to affect the Router Cache are to use Server Actions OR to use router.refresh().
So testing this out to see if logs page can get updated in real time after adding / deleting without the cache setting the page to an old version of itself